### PR TITLE
Implement priority logic for transactions

### DIFF
--- a/src/models/Models.ts
+++ b/src/models/Models.ts
@@ -68,6 +68,7 @@ export interface IScheduled extends Document {
   paymentRefundAddress: string;
   paymentAddress: string;
   paymentTx: string;
+  priority?: number;
   userId?: string;
   notes?: string;
   scheduledEthPrice?: number;

--- a/src/models/ScheduledSchema.ts
+++ b/src/models/ScheduledSchema.ts
@@ -207,6 +207,9 @@ const ScheduledSchema = new Schema({
   paymentTx: {
     type: String,
   },
+  priority: {
+    type: Number,
+  },
   userId: {
     type: String,
   },

--- a/src/services/ethereum/gas.ts
+++ b/src/services/ethereum/gas.ts
@@ -2,7 +2,7 @@ import fetch from 'node-fetch';
 import { ethers } from 'ethers';
 import { BigNumber } from 'ethers';
 
-import { DAY_MILLIS, GWEI_DECIMALS, MINUTE_MILLIS, SECOND_MILLIS } from '../../constants';
+import { ChainId, DAY_MILLIS, GWEI_DECIMALS, MINUTE_MILLIS, SECOND_MILLIS } from '../../constants';
 import { CURRENT_GAS_PRICE_FEED_URL, GAS_PRICE_FEED_URL } from '../../env';
 import { bnToNumber, createTimedCache } from '../../utils';
 import { BadRequestError } from '../../errors';
@@ -101,7 +101,7 @@ async function estimateGasSavings(): Promise<IGasSavingsResponse> {
 async function fetchEstimatedGasSavings(): Promise<IGasSavingsResponse> {
   const { gwei: minGasPrice } = await estimateGas('7d');
 
-  const provider = getProvider(1);
+  const provider = getProvider(ChainId.Ethereum);
 
   const currentGasPriceBn = await provider.getGasPrice();
   const currentGasPrice = bnToNumber(currentGasPriceBn, GWEI_DECIMALS, 0);
@@ -179,7 +179,7 @@ async function fetchCurrentSafeLowGasPrice(chainId: number): Promise<BigNumber> 
   } catch (e) {
     logger.error(e);
     // fallback - 85% of network price
-    const provider = getProvider(1);
+    const provider = getProvider(ChainId.Ethereum);
     const gasPrice = await provider.getGasPrice();
 
     return gasPrice.mul(BigNumber.from('85')).div(BigNumber.from('100'));

--- a/src/services/ethereum/processor.ts
+++ b/src/services/ethereum/processor.ts
@@ -39,7 +39,7 @@ export class Processor {
     scheduled.forEach((s) => {
       const key = makeKey(s.from, s.chainId);
       if (s.priority === undefined) {
-        s.priority = Math.floor(Math.random() * 10);
+        s.priority = 1;
       }
 
       if (!groups.has(key)) {


### PR DESCRIPTION
- Added priority (number) property in Schedules,
- Sorting txs based on address,id,nonce and priority.
- If there's no priority for a tx, the priority for that tx is set to 1.
- Picking lowest nonce and highest priority tx
- Trying to execute
- If successful marks other txs
- Else checks conditions 