### PR TITLE
Automate email notification for arbitrum tx redirecting to Arbiscan

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,8 +5,16 @@ export const DAY_MILLIS = 24 * HOUR_MILLIS;
 export const ETH_DECIMALS = 18;
 export const GWEI_DECIMALS = 9;
 export enum ChainId {
+  None = -1,
   Arbitrum = 42161,
   Ethereum = 1,
-  Arbitrum_Rinkeby = 421611,
   Ropsten = 3,
+  Arbitrum_Rinkeby = 421611,
+}
+export enum BlockExplorerUrl {
+  None = '',
+  Arbitrum = 'https://arbiscan.io/',
+  Ethereum = 'https://etherscan.io/',
+  Ropsten = 'https://ropsten.etherscan.io/',
+  Arbitrum_Rinkeby = 'https://testnet.arbiscan.io/',
 }

--- a/src/services/mail.ts
+++ b/src/services/mail.ts
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js';
 
 import { IScheduled } from '../models/Models';
 import logger from './logger';
+import { ChainId, BlockExplorerUrl } from '../constants';
 
 const API_KEY = process.env.SENDGRID_API_KEY;
 const SUCCESS_EMAILS = process.env.SUCCESS_EMAILS === 'true';
@@ -49,6 +50,13 @@ async function send(scheduledTx: IMailParams, status: MailStatus): Promise<void>
   const name = scheduledTx.assetName || '';
   const from = scheduledTx.from;
   const subject = `${mailSubjects[status]} ${amount} ${name} from ${from}`;
+  const networkName: string = ChainId[scheduledTx.chainId];
+  const txUrl: string =
+    BlockExplorerUrl[networkName as keyof typeof BlockExplorerUrl] + 'tx/' + scheduledTx.transactionHash;
+  const fromUrl: string =
+    BlockExplorerUrl[networkName as keyof typeof BlockExplorerUrl] + 'address/' + scheduledTx.from;
+  const conditionAssetUrl: string =
+    BlockExplorerUrl[networkName as keyof typeof BlockExplorerUrl] + 'address/' + scheduledTx.conditionAsset;
 
   try {
     logger.info(
@@ -68,12 +76,12 @@ async function send(scheduledTx: IMailParams, status: MailStatus): Promise<void>
         name,
         type: scheduledTx.assetType || '',
         chainId: scheduledTx.chainId,
-        txHash: scheduledTx.transactionHash,
+        txHash: txUrl,
         nonce: scheduledTx.nonce,
-        from,
+        from: fromUrl,
         conditionBlock: scheduledTx.conditionBlock,
         conditionAmount: scheduledTx.conditionAmount,
-        conditionAsset: scheduledTx.conditionAsset,
+        conditionAsset: conditionAssetUrl,
         timeCondition: scheduledTx.timeCondition,
         timeConditionTZ: scheduledTx.timeConditionTZ,
         createdAt: scheduledTx.createdAt,
@@ -105,11 +113,11 @@ async function send(scheduledTx: IMailParams, status: MailStatus): Promise<void>
           name,
           type: scheduledTx.assetType || '',
           chainId: scheduledTx.chainId,
-          txHash: scheduledTx.transactionHash,
+          txHash: txUrl,
           nonce: scheduledTx.nonce,
-          from,
+          from: fromUrl,
           conditionBlock: scheduledTx.conditionBlock,
-          conditionAmount: scheduledTx.conditionAmount,
+          conditionAmount: conditionAssetUrl,
           conditionAsset: scheduledTx.conditionAsset,
           timeCondition: scheduledTx.timeCondition,
           timeConditionTZ: scheduledTx.timeConditionTZ,


### PR DESCRIPTION
With this update tx, from and assetCondition type field on automate emails display relevant block url based on chainId of the tx.